### PR TITLE
Allow sink configuration via Serilog.Settings.Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ Serilog.ILogger log = new LoggerConfiguration()
   .CreateLogger();
 ```
 
+Used in conjunction with [Serilog.Settings.Configuration](https://github.com/serilog/serilog-settings-configuration) the sink can also be configured in the following way
+```json
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+    },
+    "WriteTo": [
+      {
+        "name": "Udp",
+        "Args": {
+          "remoteAddress": "127.0.0.1",
+          "remotePort": "7071"
+        } 
+      }
+    ]
+  }
+```
+
 ### Typical use case
 
 Producing log events is only half the story. Unless you are consuming them in a matter that benefits you in development or production, there is really no need to produce them in the first place.

--- a/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
@@ -34,6 +34,58 @@ namespace Serilog
         /// </summary>
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="remoteAddress">
+        /// The IPAddress of the remote host or multicast group to which the UDP
+        /// client should sent the logging event.
+        /// </param>
+        /// <param name="remotePort">
+        /// The TCP port of the remote host or multicast group to which the UDP client should sent
+        /// the logging event.
+        /// </param>
+        /// <param name="localPort">
+        /// The TCP port from which the UDP client will communicate. The default is 0 and will
+        /// cause the UDP client not to bind to a local port.
+        /// </param>
+        /// <param name="restrictedToMinimumLevel">
+        /// The minimum level for events passed through the sink. The default is
+        /// <see cref="LevelAlias.Minimum"/>.
+        /// </param>
+        /// <param name="outputTemplate">
+        /// A message template describing the format used to write to the sink. The default is
+        /// "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level}] {Message}{NewLine}{Exception}".
+        /// </param>
+        /// <param name="formatProvider">
+        /// Supplies culture-specific formatting information, or null.
+        /// </param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        public static LoggerConfiguration Udp(
+            this LoggerSinkConfiguration sinkConfiguration,
+            string remoteAddress,
+            int remotePort,
+            int localPort = 0,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = DefaultOutputTemplate,
+            IFormatProvider formatProvider = null)
+        {
+            if (sinkConfiguration == null)
+                throw new ArgumentNullException(nameof(sinkConfiguration));
+            if (outputTemplate == null)
+                throw new ArgumentNullException(nameof(outputTemplate));
+
+            var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+            return Udp(
+                sinkConfiguration,
+                IPAddress.Parse(remoteAddress),
+                remotePort,
+                formatter,
+                localPort,
+                restrictedToMinimumLevel);
+        }
+        
+        /// <summary>
+        /// Adds a sink that sends log events as UDP packages over the network.
+        /// </summary>
+        /// <param name="sinkConfiguration">Logger sink configuration.</param>
+        /// <param name="remoteAddress">
         /// The <see cref="IPAddress"/> of the remote host or multicast group to which the UDP
         /// client should sent the logging event.
         /// </param>


### PR DESCRIPTION
This PR adds an additional extension method to accept the remoteAddress as a string and then parses it to an IPAddress object.

This will allow the sink to be configured using the Serilog.Settings.Configuration package.