### PR TITLE
XML escape serialized properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 - [#42](https://github.com/FantasticFiasco/serilog-sinks-udp/pull/42) Revert to support IPv4 on networks without IPv6 (contribution by [brettdavis-bmw](https://github.com/brettdavis-bmw))
 - [#45](https://github.com/FantasticFiasco/serilog-sinks-udp/issues/45) Correctly XML escape exception message serialized by `Log4jTextFormatter`
-- [#51](https://github.com/FantasticFiasco/serilog-sinks-udp/issues/51) Correctly XML escape exception all properties serialized by `Log4jTextFormatter` and `Log4netTextFormatter`
+- [#51](https://github.com/FantasticFiasco/serilog-sinks-udp/issues/51) Correctly XML escape all properties serialized by `Log4jTextFormatter` and `Log4netTextFormatter`
 
 ### :dizzy: Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 ### :syringe: Fixed
 
 - [#42](https://github.com/FantasticFiasco/serilog-sinks-udp/pull/42) Revert to support IPv4 on networks without IPv6 (contribution by [brettdavis-bmw](https://github.com/brettdavis-bmw))
-- [#45](https://github.com/FantasticFiasco/serilog-sinks-udp/pull/45) Correctly XML escape exception message serialized by `Log4jTextFormatter`
+- [#45](https://github.com/FantasticFiasco/serilog-sinks-udp/issues/45) Correctly XML escape exception message serialized by `Log4jTextFormatter`
+- [#51](https://github.com/FantasticFiasco/serilog-sinks-udp/issues/51) Correctly XML escape exception all properties serialized by `Log4jTextFormatter` and `Log4netTextFormatter`
 
 ### :dizzy: Changed
 

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/Private/RemoteEndPoint.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/Private/RemoteEndPoint.cs
@@ -36,6 +36,14 @@ namespace Serilog.Sinks.Udp.Private
 
         public int Port { get; }
 
+        /// <summary>
+        /// It's a very small performance optimization to parse the IP address and use it instead
+        /// of having the HTTP client trying to resolve the address and figure out that it isn't a
+        /// hostname at all but instead an ordinary IP address.
+        ///
+        /// A small optimization indeed, but one that was requested by one of the consumers of the
+        /// package.
+        /// </summary>
         public IPEndPoint IPEndPoint { get; }
     }
 }

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/Private/XmlSerializer.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/Private/XmlSerializer.cs
@@ -17,6 +17,10 @@ using System.Text;
 
 namespace Serilog.Sinks.Udp.Private
 {
+    /// <remarks>
+    /// The methods in this class where influenced by
+    /// https://weblog.west-wind.com/posts/2018/Nov/30/Returning-an-XML-Encoded-String-in-NET.
+    /// </remarks>
     internal class XmlSerializer
     {
         private const char LtCharacter = '<';
@@ -41,10 +45,6 @@ namespace Serilog.Sinks.Udp.Private
         private const string SerializedCr = "&#xD;";
         private const string SerializedTab = "&#x9;";
 
-        /// <remarks>
-        /// This method has been copied from
-        /// https://weblog.west-wind.com/posts/2018/Nov/30/Returning-an-XML-Encoded-String-in-NET.
-        /// </remarks>
         internal void SerializeXmlValue(TextWriter output, string text, bool isAttribute)
         {
             foreach (var character in text)

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/Private/XmlSerializer.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/Private/XmlSerializer.cs
@@ -1,0 +1,115 @@
+﻿// Copyright 2015-2019 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using System.Text;
+
+namespace Serilog.Sinks.Udp.Private
+{
+    internal static class XmlSerializer
+    {
+        private const char LtCharacter = '<';
+        private const char GtCharacter = '>';
+        private const char AmpCharacter = '&';
+        private const char QuotCharacter = '\"';
+        private const char AposCharacter = '\'';
+        private const char LfCharacter = '\n';
+        private const char CrCharacter = '\r';
+        private const char TabCharacter = '\t';
+
+        private const string LfString = "\n";
+        private const string CrString = "\r";
+        private const string TabString = "\t";
+
+        private const string SerializedLt = "&lt;";
+        private const string SerializedGt = "&gt;";
+        private const string SerializedAmp = "&amp;";
+        private const string SerializedQuot = "&quot;";
+        private const string SerializedApos = "&apos;";
+        private const string SerializedLf = "&#xA;";
+        private const string SerializedCr = "&#xD;";
+        private const string SerializedTab = "&#x9;";
+
+        /// <remarks>
+        /// This method has been copied from
+        /// https://weblog.west-wind.com/posts/2018/Nov/30/Returning-an-XML-Encoded-String-in-NET.
+        /// </remarks>
+        internal static void SerializeXmlValue(TextWriter output, string text, bool isAttribute)
+        {
+            foreach (var character in text)
+            {
+                output.Write(SerializeXmlValue(character, isAttribute));
+            }
+        }
+
+        internal static string SerializeXmlValue(string text, bool isAttribute)
+        {
+            var builder = new StringBuilder();
+
+            foreach (var character in text)
+            {
+                builder.Append(SerializeXmlValue(character, isAttribute));
+            }
+
+            return builder.ToString();
+        }
+
+        private static string SerializeXmlValue(char character, bool isAttribute)
+        {
+            if (character == LtCharacter)
+            {
+                return SerializedLt;
+            }
+
+            if (character == GtCharacter)
+            {
+                return SerializedGt;
+            }
+
+            if (character == AmpCharacter)
+            {
+                return SerializedAmp;
+            }
+
+            // Special handling for quotes
+            if (isAttribute && character == QuotCharacter)
+            {
+                return SerializedQuot;
+            }
+
+            if (isAttribute && character == AposCharacter)
+            {
+                return SerializedApos;
+            }
+
+            // Legal sub-chr32 characters
+            if (character == LfCharacter)
+            {
+                return isAttribute ? SerializedLf : LfString;
+            }
+
+            if (character == CrCharacter)
+            {
+                return isAttribute ? SerializedCr : CrString;
+            }
+
+            if (character == TabCharacter)
+            {
+                return isAttribute ? SerializedTab : TabString;
+            }
+
+            return character.ToString();
+        }
+    }
+}

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/Private/XmlSerializer.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/Private/XmlSerializer.cs
@@ -17,7 +17,7 @@ using System.Text;
 
 namespace Serilog.Sinks.Udp.Private
 {
-    internal static class XmlSerializer
+    internal class XmlSerializer
     {
         private const char LtCharacter = '<';
         private const char GtCharacter = '>';
@@ -45,7 +45,7 @@ namespace Serilog.Sinks.Udp.Private
         /// This method has been copied from
         /// https://weblog.west-wind.com/posts/2018/Nov/30/Returning-an-XML-Encoded-String-in-NET.
         /// </remarks>
-        internal static void SerializeXmlValue(TextWriter output, string text, bool isAttribute)
+        internal void SerializeXmlValue(TextWriter output, string text, bool isAttribute)
         {
             foreach (var character in text)
             {
@@ -53,7 +53,7 @@ namespace Serilog.Sinks.Udp.Private
             }
         }
 
-        internal static string SerializeXmlValue(string text, bool isAttribute)
+        internal string SerializeXmlValue(string text, bool isAttribute)
         {
             var builder = new StringBuilder();
 

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/TextFormatters/Log4jTextFormatter.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/TextFormatters/Log4jTextFormatter.cs
@@ -28,6 +28,16 @@ namespace Serilog.Sinks.Udp.TextFormatters
         private static readonly string SourceContextPropertyName = "SourceContext";
         private static readonly string ThreadIdPropertyName = "ThreadId";
 
+        private readonly XmlSerializer xmlSerializer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4jTextFormatter"/> class.
+        /// </summary>
+        public Log4jTextFormatter()
+        {
+            xmlSerializer = new XmlSerializer();
+        }
+
         /// <summary>
         /// Format the log event into the output.
         /// </summary>
@@ -50,12 +60,12 @@ namespace Serilog.Sinks.Udp.TextFormatters
             output.Write("</log4j:event>");
         }
 
-        private static void WriteLogger(LogEvent logEvent, TextWriter output)
+        private void WriteLogger(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Properties.TryGetValue(SourceContextPropertyName, out var sourceContext))
             {
                 var sourceContextValue = ((ScalarValue)sourceContext).Value.ToString();
-                output.Write($" logger=\"{XmlSerializer.SerializeXmlValue(sourceContextValue, true)}\"");
+                output.Write($" logger=\"{xmlSerializer.SerializeXmlValue(sourceContextValue, true)}\"");
             }
         }
 
@@ -100,23 +110,23 @@ namespace Serilog.Sinks.Udp.TextFormatters
             output.Write($" level=\"{level}\"");
         }
 
-        private static void WriteThread(LogEvent logEvent, TextWriter output)
+        private void WriteThread(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Properties.TryGetValue(ThreadIdPropertyName, out var threadId))
             {
                 var threadIdValue = ((ScalarValue)threadId).Value.ToString();
-                output.Write($" thread=\"{XmlSerializer.SerializeXmlValue(threadIdValue, true)}\"");
+                output.Write($" thread=\"{xmlSerializer.SerializeXmlValue(threadIdValue, true)}\"");
             }
         }
 
-        private static void WriteMessage(LogEvent logEvent, TextWriter output)
+        private void WriteMessage(LogEvent logEvent, TextWriter output)
         {
             output.Write("<log4j:message>");
-            XmlSerializer.SerializeXmlValue(output, logEvent.RenderMessage(), false);
+            xmlSerializer.SerializeXmlValue(output, logEvent.RenderMessage(), false);
             output.Write("</log4j:message>");
         }
 
-        private static void WriteException(LogEvent logEvent, TextWriter output)
+        private void WriteException(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Exception == null)
             {
@@ -124,7 +134,7 @@ namespace Serilog.Sinks.Udp.TextFormatters
             }
 
             output.Write("<log4j:throwable>");
-            XmlSerializer.SerializeXmlValue(output, logEvent.Exception.ToString(), false);
+            xmlSerializer.SerializeXmlValue(output, logEvent.Exception.ToString(), false);
             output.Write("</log4j:throwable>");
         }
     }

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/TextFormatters/Log4netTextFormatter.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/TextFormatters/Log4netTextFormatter.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2015-2019 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@
 using Serilog.Events;
 using Serilog.Formatting;
 using System.IO;
+using Serilog.Sinks.Udp.Private;
 
 namespace Serilog.Sinks.Udp.TextFormatters
 {
@@ -25,10 +26,11 @@ namespace Serilog.Sinks.Udp.TextFormatters
     {
         private static readonly string SourceContextPropertyName = "SourceContext";
         private static readonly string ThreadIdPropertyName = "ThreadId";
-        private static readonly string MachineNamePropertyName = "MachineName";
         private static readonly string UserNamePropertyName = "EnvironmentUserName";
-        private static readonly string MethodPropertyName = "Method";
         private static readonly string ProcessNamePropertyName = "ProcessName";
+        private static readonly string MethodPropertyName = "Method";
+        private static readonly string MachineNamePropertyName = "MachineName";
+
 
         /// <summary>
         /// Format the log event into the output.
@@ -62,51 +64,12 @@ namespace Serilog.Sinks.Udp.TextFormatters
             output.Write("</log4net:event>");
         }
 
-        private static void WriteProcessName(LogEvent logEvent, TextWriter output)
-        {
-            if (logEvent.Properties.TryGetValue(ProcessNamePropertyName, out LogEventPropertyValue processName))
-            {
-                output.Write($" domain=\"{((ScalarValue)processName).Value}\"");
-            }
-        }
-
-        private static void WriteLocationInfoClass(LogEvent logEvent, TextWriter output)
-        {
-            if (logEvent.Properties.TryGetValue(SourceContextPropertyName, out LogEventPropertyValue sourceContext))
-            {
-                output.Write($" class=\"{((ScalarValue)sourceContext).Value}\"");
-            }
-        }
-
-        private static void WriteLocationInfoMethod(LogEvent logEvent, TextWriter output)
-        {
-            if (logEvent.Properties.TryGetValue(MethodPropertyName, out LogEventPropertyValue methodName))
-            {
-                output.Write($" method=\"{((ScalarValue)methodName).Value}\"");
-            }
-        }
-
         private static void WriteLogger(LogEvent logEvent, TextWriter output)
         {
-            if (logEvent.Properties.TryGetValue(SourceContextPropertyName, out LogEventPropertyValue sourceContext))
+            if (logEvent.Properties.TryGetValue(SourceContextPropertyName, out var sourceContext))
             {
-                output.Write($" logger=\"{((ScalarValue)sourceContext).Value}\"");
-            }
-        }
-
-        private static void WriteUserName(LogEvent logEvent, TextWriter output)
-        {
-            if (logEvent.Properties.TryGetValue(UserNamePropertyName, out LogEventPropertyValue userName))
-            {
-                output.Write($" username=\"{((ScalarValue)userName).Value}\"");
-            }
-        }
-
-        private static void WriteHostName(LogEvent logEvent, TextWriter output)
-        {
-            if (logEvent.Properties.TryGetValue(MachineNamePropertyName, out LogEventPropertyValue machineName))
-            {
-                output.Write($" <log4net:data name=\"log4net:HostName\" value=\"{((ScalarValue)machineName).Value}\"></log4net:data>");
+                var sourceContextValue = ((ScalarValue)sourceContext).Value.ToString();
+                output.Write($" logger=\"{XmlSerializer.SerializeXmlValue(sourceContextValue, true)}\"");
             }
         }
 
@@ -152,16 +115,62 @@ namespace Serilog.Sinks.Udp.TextFormatters
 
         private static void WriteThread(LogEvent logEvent, TextWriter output)
         {
-            if (logEvent.Properties.TryGetValue(ThreadIdPropertyName, out LogEventPropertyValue threadId))
+            if (logEvent.Properties.TryGetValue(ThreadIdPropertyName, out var threadId))
             {
-                output.Write($" thread=\"{((ScalarValue)threadId).Value}\"");
+                var threadIdValue = ((ScalarValue)threadId).Value.ToString();
+                output.Write($" thread=\"{XmlSerializer.SerializeXmlValue(threadIdValue, true)}\"");
+            }
+        }
+
+        private static void WriteUserName(LogEvent logEvent, TextWriter output)
+        {
+            if (logEvent.Properties.TryGetValue(UserNamePropertyName, out var userName))
+            {
+                var userNameValue = ((ScalarValue)userName).Value.ToString();
+                output.Write($" username=\"{XmlSerializer.SerializeXmlValue(userNameValue, true)}\"");
+            }
+        }
+
+        private static void WriteProcessName(LogEvent logEvent, TextWriter output)
+        {
+            if (logEvent.Properties.TryGetValue(ProcessNamePropertyName, out var processName))
+            {
+                var processNameValue = ((ScalarValue)processName).Value.ToString();
+                output.Write($" domain=\"{XmlSerializer.SerializeXmlValue(processNameValue, true)}\"");
+            }
+        }
+
+        private static void WriteLocationInfoClass(LogEvent logEvent, TextWriter output)
+        {
+            if (logEvent.Properties.TryGetValue(SourceContextPropertyName, out var sourceContext))
+            {
+                var sourceContextValue = ((ScalarValue)sourceContext).Value.ToString();
+                output.Write($" class=\"{XmlSerializer.SerializeXmlValue(sourceContextValue, true)}\"");
+            }
+        }
+
+        private static void WriteLocationInfoMethod(LogEvent logEvent, TextWriter output)
+        {
+            if (logEvent.Properties.TryGetValue(MethodPropertyName, out var methodName))
+            {
+                var methodNameValue = ((ScalarValue)methodName).Value.ToString();
+                output.Write($" method=\"{XmlSerializer.SerializeXmlValue(methodNameValue, true)}\"");
+            }
+        }
+
+        private static void WriteHostName(LogEvent logEvent, TextWriter output)
+        {
+            if (logEvent.Properties.TryGetValue(MachineNamePropertyName, out var machineName))
+            {
+                var machineNameValue = ((ScalarValue)machineName).Value.ToString();
+                output.Write($" <log4net:data name=\"log4net:HostName\" value=\"{XmlSerializer.SerializeXmlValue(machineNameValue, true)}\"></log4net:data>");
             }
         }
 
         private static void WriteMessage(LogEvent logEvent, TextWriter output)
         {
             output.Write("<log4net:message>");
-            logEvent.RenderMessage(output);
+            XmlSerializer.SerializeXmlValue(output, logEvent.RenderMessage(), false);
             output.Write("</log4net:message>");
         }
 
@@ -172,7 +181,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
                 return;
             }
 
-            output.Write($"<log4net:throwable>{logEvent.Exception}</log4net:throwable>");
+            output.Write("<log4net:throwable>");
+            XmlSerializer.SerializeXmlValue(output, logEvent.Exception.ToString(), false);
+            output.Write("</log4net:throwable>");
         }
     }
 }

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/TextFormatters/Log4netTextFormatter.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/TextFormatters/Log4netTextFormatter.cs
@@ -31,6 +31,15 @@ namespace Serilog.Sinks.Udp.TextFormatters
         private static readonly string MethodPropertyName = "Method";
         private static readonly string MachineNamePropertyName = "MachineName";
 
+        private readonly XmlSerializer xmlSerializer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4netTextFormatter"/> class.
+        /// </summary>
+        public Log4netTextFormatter()
+        {
+            xmlSerializer = new XmlSerializer();
+        }
 
         /// <summary>
         /// Format the log event into the output.
@@ -64,12 +73,12 @@ namespace Serilog.Sinks.Udp.TextFormatters
             output.Write("</log4net:event>");
         }
 
-        private static void WriteLogger(LogEvent logEvent, TextWriter output)
+        private void WriteLogger(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Properties.TryGetValue(SourceContextPropertyName, out var sourceContext))
             {
                 var sourceContextValue = ((ScalarValue)sourceContext).Value.ToString();
-                output.Write($" logger=\"{XmlSerializer.SerializeXmlValue(sourceContextValue, true)}\"");
+                output.Write($" logger=\"{xmlSerializer.SerializeXmlValue(sourceContextValue, true)}\"");
             }
         }
 
@@ -113,68 +122,68 @@ namespace Serilog.Sinks.Udp.TextFormatters
             output.Write($" level=\"{level}\"");
         }
 
-        private static void WriteThread(LogEvent logEvent, TextWriter output)
+        private void WriteThread(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Properties.TryGetValue(ThreadIdPropertyName, out var threadId))
             {
                 var threadIdValue = ((ScalarValue)threadId).Value.ToString();
-                output.Write($" thread=\"{XmlSerializer.SerializeXmlValue(threadIdValue, true)}\"");
+                output.Write($" thread=\"{xmlSerializer.SerializeXmlValue(threadIdValue, true)}\"");
             }
         }
 
-        private static void WriteUserName(LogEvent logEvent, TextWriter output)
+        private void WriteUserName(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Properties.TryGetValue(UserNamePropertyName, out var userName))
             {
                 var userNameValue = ((ScalarValue)userName).Value.ToString();
-                output.Write($" username=\"{XmlSerializer.SerializeXmlValue(userNameValue, true)}\"");
+                output.Write($" username=\"{xmlSerializer.SerializeXmlValue(userNameValue, true)}\"");
             }
         }
 
-        private static void WriteProcessName(LogEvent logEvent, TextWriter output)
+        private void WriteProcessName(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Properties.TryGetValue(ProcessNamePropertyName, out var processName))
             {
                 var processNameValue = ((ScalarValue)processName).Value.ToString();
-                output.Write($" domain=\"{XmlSerializer.SerializeXmlValue(processNameValue, true)}\"");
+                output.Write($" domain=\"{xmlSerializer.SerializeXmlValue(processNameValue, true)}\"");
             }
         }
 
-        private static void WriteLocationInfoClass(LogEvent logEvent, TextWriter output)
+        private void WriteLocationInfoClass(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Properties.TryGetValue(SourceContextPropertyName, out var sourceContext))
             {
                 var sourceContextValue = ((ScalarValue)sourceContext).Value.ToString();
-                output.Write($" class=\"{XmlSerializer.SerializeXmlValue(sourceContextValue, true)}\"");
+                output.Write($" class=\"{xmlSerializer.SerializeXmlValue(sourceContextValue, true)}\"");
             }
         }
 
-        private static void WriteLocationInfoMethod(LogEvent logEvent, TextWriter output)
+        private void WriteLocationInfoMethod(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Properties.TryGetValue(MethodPropertyName, out var methodName))
             {
                 var methodNameValue = ((ScalarValue)methodName).Value.ToString();
-                output.Write($" method=\"{XmlSerializer.SerializeXmlValue(methodNameValue, true)}\"");
+                output.Write($" method=\"{xmlSerializer.SerializeXmlValue(methodNameValue, true)}\"");
             }
         }
 
-        private static void WriteHostName(LogEvent logEvent, TextWriter output)
+        private void WriteHostName(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Properties.TryGetValue(MachineNamePropertyName, out var machineName))
             {
                 var machineNameValue = ((ScalarValue)machineName).Value.ToString();
-                output.Write($" <log4net:data name=\"log4net:HostName\" value=\"{XmlSerializer.SerializeXmlValue(machineNameValue, true)}\"></log4net:data>");
+                output.Write($" <log4net:data name=\"log4net:HostName\" value=\"{xmlSerializer.SerializeXmlValue(machineNameValue, true)}\"></log4net:data>");
             }
         }
 
-        private static void WriteMessage(LogEvent logEvent, TextWriter output)
+        private void WriteMessage(LogEvent logEvent, TextWriter output)
         {
             output.Write("<log4net:message>");
-            XmlSerializer.SerializeXmlValue(output, logEvent.RenderMessage(), false);
+            xmlSerializer.SerializeXmlValue(output, logEvent.RenderMessage(), false);
             output.Write("</log4net:message>");
         }
 
-        private static void WriteException(LogEvent logEvent, TextWriter output)
+        private void WriteException(LogEvent logEvent, TextWriter output)
         {
             if (logEvent.Exception == null)
             {
@@ -182,7 +191,7 @@ namespace Serilog.Sinks.Udp.TextFormatters
             }
 
             output.Write("<log4net:throwable>");
-            XmlSerializer.SerializeXmlValue(output, logEvent.Exception.ToString(), false);
+            xmlSerializer.SerializeXmlValue(output, logEvent.Exception.ToString(), false);
             output.Write("</log4net:throwable>");
         }
     }

--- a/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4jTextFormatterShould.cs
+++ b/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4jTextFormatterShould.cs
@@ -42,6 +42,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should be escaped in a XML attribute
         [InlineData("Some \" source context", "Some &quot; source context")]
         [InlineData("Some ' source context", "Some &apos; source context")]
+        [InlineData("Some \n source context", "Some &#xA; source context")]
+        [InlineData("Some \r source context", "Some &#xD; source context")]
+        [InlineData("Some \t source context", "Some &#x9; source context")]
         public void WriteEscapedLoggerAttribute(string sourceContext, string expected)
         {
             // Arrange
@@ -106,6 +109,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should be escaped in a XML attribute
         [InlineData("Some \" thread", "Some &quot; thread")]
         [InlineData("Some ' thread", "Some &apos; thread")]
+        [InlineData("Some \n thread", "Some &#xA; thread")]
+        [InlineData("Some \r thread", "Some &#xD; thread")]
+        [InlineData("Some \t thread", "Some &#x9; thread")]
         public void WriteEscapedTheadAttribute(string thread, string expected)
         {
             // Arrange
@@ -142,6 +148,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should not be escaped in a XML element
         [InlineData("Some \" message", "Some \" message")]
         [InlineData("Some ' message", "Some ' message")]
+        [InlineData("Some \n message", "Some \n message")]
+        [InlineData("Some \r message", "Some \r message")]
+        [InlineData("Some \t message", "Some \t message")]
         public void WriteEscapedMessageElement(string message, string expected)
         {
             // Arrange
@@ -153,7 +162,12 @@ namespace Serilog.Sinks.Udp.TextFormatters
             // Assert
             output.ToString().ShouldContain($"<log4j:message>{expected}</log4j:message>");
 
-            // Lets make sure that the escaped XML can be deserialized back into its original form
+            // Lets make sure that the escaped XML can be deserialized back into its original form.
+            //
+            // "\r" are deserialized into "\n" by the .NET XML serializer, thus we need to
+            // compensate for that.
+            message = message.Replace("\r", "\n");
+
             Deserialize().Root.Element(Namespace + "message").Value.ShouldBe(message);
         }
 
@@ -177,6 +191,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should not be escaped in a XML element
         [InlineData("Some \" message", "Some \" message")]
         [InlineData("Some ' message", "Some ' message")]
+        [InlineData("Some \n message", "Some \n message")]
+        [InlineData("Some \r message", "Some \r message")]
+        [InlineData("Some \t message", "Some \t message")]
         public void WriteEscapedExceptionElement(string message, string expected)
         {
             // Arrange
@@ -188,7 +205,12 @@ namespace Serilog.Sinks.Udp.TextFormatters
             // Assert
             output.ToString().ShouldContain($"<log4j:throwable>System.DivideByZeroException: {expected}</log4j:throwable>");
 
-            // Lets make sure that the escaped XML can be deserialized back into its original form
+            // Lets make sure that the escaped XML can be deserialized back into its original form.
+            //
+            // "\r" are deserialized into "\n" by the .NET XML serializer, thus we need to
+            // compensate for that.
+            message = message.Replace("\r", "\n");
+
             Deserialize().Root.Element(Namespace + "throwable").Value.ShouldBe($"System.DivideByZeroException: {message}");
         }
 

--- a/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4jTextFormatterShould.cs
+++ b/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4jTextFormatterShould.cs
@@ -35,6 +35,29 @@ namespace Serilog.Sinks.Udp.TextFormatters
             Deserialize().Root.Attribute("logger").Value.ShouldBe("source context");
         }
 
+        [Theory]
+        [InlineData("Some < source context", "Some &lt; source context")]
+        [InlineData("Some > source context", "Some &gt; source context")]
+        [InlineData("Some & source context", "Some &amp; source context")]
+        // The following characters should be escaped in a XML attribute
+        [InlineData("Some \" source context", "Some &quot; source context")]
+        [InlineData("Some ' source context", "Some &apos; source context")]
+        public void WriteEscapedLoggerAttribute(string sourceContext, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent();
+            logEvent.AddOrUpdateProperty(new LogEventProperty("SourceContext", new ScalarValue(sourceContext)));
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($" logger=\"{expected}\"");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Attribute("logger").Value.ShouldBe(sourceContext);
+        }
+
         [Fact]
         public void WriteTimestampAttribute()
         {
@@ -76,6 +99,29 @@ namespace Serilog.Sinks.Udp.TextFormatters
             Deserialize().Root.Attribute("thread").Value.ShouldBe("1");
         }
 
+        [Theory]
+        [InlineData("Some < thread", "Some &lt; thread")]
+        [InlineData("Some > thread", "Some &gt; thread")]
+        [InlineData("Some & thread", "Some &amp; thread")]
+        // The following characters should be escaped in a XML attribute
+        [InlineData("Some \" thread", "Some &quot; thread")]
+        [InlineData("Some ' thread", "Some &apos; thread")]
+        public void WriteEscapedTheadAttribute(string thread, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent();
+            logEvent.AddOrUpdateProperty(new LogEventProperty("ThreadId", new ScalarValue(thread)));
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($" thread=\"{expected}\"");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Attribute("thread").Value.ShouldBe(thread);
+        }
+
         [Fact]
         public void WriteMessageElement()
         {
@@ -87,6 +133,28 @@ namespace Serilog.Sinks.Udp.TextFormatters
 
             // Assert
             Deserialize().Root.Element(Namespace + "message").Value.ShouldBe("Some message");
+        }
+
+        [Theory]
+        [InlineData("Some < message", "Some &lt; message")]
+        [InlineData("Some > message", "Some &gt; message")]
+        [InlineData("Some & message", "Some &amp; message")]
+        // The following characters should not be escaped in a XML element
+        [InlineData("Some \" message", "Some \" message")]
+        [InlineData("Some ' message", "Some ' message")]
+        public void WriteEscapedMessageElement(string message, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent(message: message);
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($"<log4j:message>{expected}</log4j:message>");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Element(Namespace + "message").Value.ShouldBe(message);
         }
 
         [Fact]
@@ -103,12 +171,12 @@ namespace Serilog.Sinks.Udp.TextFormatters
         }
 
         [Theory]
-        [InlineData("<", "&lt;")]
-        [InlineData(">", "&gt;")]
-        [InlineData("&", "&amp;")]
-        // The following characters should not be escaped in the error message
-        [InlineData("\"", "\"")]
-        [InlineData("'", "'")]
+        [InlineData("Some < message", "Some &lt; message")]
+        [InlineData("Some > message", "Some &gt; message")]
+        [InlineData("Some & message", "Some &amp; message")]
+        // The following characters should not be escaped in a XML element
+        [InlineData("Some \" message", "Some \" message")]
+        [InlineData("Some ' message", "Some ' message")]
         public void WriteEscapedExceptionElement(string message, string expected)
         {
             // Arrange
@@ -119,6 +187,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
 
             // Assert
             output.ToString().ShouldContain($"<log4j:throwable>System.DivideByZeroException: {expected}</log4j:throwable>");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Element(Namespace + "throwable").Value.ShouldBe($"System.DivideByZeroException: {message}");
         }
 
         private XDocument Deserialize()

--- a/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4netTextFormatterShould.cs
+++ b/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4netTextFormatterShould.cs
@@ -42,6 +42,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should be escaped in a XML attribute
         [InlineData("Some \" source context", "Some &quot; source context")]
         [InlineData("Some ' source context", "Some &apos; source context")]
+        [InlineData("Some \n source context", "Some &#xA; source context")]
+        [InlineData("Some \r source context", "Some &#xD; source context")]
+        [InlineData("Some \t source context", "Some &#x9; source context")]
         public void WriteEscapedLoggerAttribute(string sourceContext, string expected)
         {
             // Arrange
@@ -106,6 +109,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should be escaped in a XML attribute
         [InlineData("Some \" thread", "Some &quot; thread")]
         [InlineData("Some ' thread", "Some &apos; thread")]
+        [InlineData("Some \n thread", "Some &#xA; thread")]
+        [InlineData("Some \r thread", "Some &#xD; thread")]
+        [InlineData("Some \t thread", "Some &#x9; thread")]
         public void WriteEscapedTheadAttribute(string thread, string expected)
         {
             // Arrange
@@ -143,6 +149,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should be escaped in a XML attribute
         [InlineData("Some \" username", "Some &quot; username")]
         [InlineData("Some ' username", "Some &apos; username")]
+        [InlineData("Some \n username", "Some &#xA; username")]
+        [InlineData("Some \r username", "Some &#xD; username")]
+        [InlineData("Some \t username", "Some &#x9; username")]
         public void WriteEscapedUsernameAttribute(string username, string expected)
         {
             // Arrange
@@ -180,6 +189,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should be escaped in a XML attribute
         [InlineData("Some \" process name", "Some &quot; process name")]
         [InlineData("Some ' process name", "Some &apos; process name")]
+        [InlineData("Some \n process name", "Some &#xA; process name")]
+        [InlineData("Some \r process name", "Some &#xD; process name")]
+        [InlineData("Some \t process name", "Some &#x9; process name")]
         public void WriteEscapedDomainAttribute(string processName, string expected)
         {
             // Arrange
@@ -217,6 +229,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should be escaped in a XML attribute
         [InlineData("Some \" source context", "Some &quot; source context")]
         [InlineData("Some ' source context", "Some &apos; source context")]
+        [InlineData("Some \n source context", "Some &#xA; source context")]
+        [InlineData("Some \r source context", "Some &#xD; source context")]
+        [InlineData("Some \t source context", "Some &#x9; source context")]
         public void WriteEscapedClassAttribute(string sourceContext, string expected)
         {
             // Arrange
@@ -254,6 +269,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should be escaped in a XML attribute
         [InlineData("Some \" method", "Some &quot; method")]
         [InlineData("Some ' method", "Some &apos; method")]
+        [InlineData("Some \n method", "Some &#xA; method")]
+        [InlineData("Some \r method", "Some &#xD; method")]
+        [InlineData("Some \t method", "Some &#x9; method")]
         public void WriteEscapedMethodAttribute(string method, string expected)
         {
             // Arrange
@@ -291,6 +309,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should be escaped in a XML attribute
         [InlineData("Some \" hostname", "Some &quot; hostname")]
         [InlineData("Some ' hostname", "Some &apos; hostname")]
+        [InlineData("Some \n hostname", "Some &#xA; hostname")]
+        [InlineData("Some \r hostname", "Some &#xD; hostname")]
+        [InlineData("Some \t hostname", "Some &#x9; hostname")]
         public void WriteEscapedHostNameAttribute(string hostname, string expected)
         {
             // Arrange
@@ -327,6 +348,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should not be escaped in a XML element
         [InlineData("Some \" message", "Some \" message")]
         [InlineData("Some ' message", "Some ' message")]
+        [InlineData("Some \n message", "Some \n message")]
+        [InlineData("Some \r message", "Some \r message")]
+        [InlineData("Some \t message", "Some \t message")]
         public void WriteEscapedMessageElement(string message, string expected)
         {
             // Arrange
@@ -338,7 +362,12 @@ namespace Serilog.Sinks.Udp.TextFormatters
             // Assert
             output.ToString().ShouldContain($"<log4net:message>{expected}</log4net:message>");
 
-            // Lets make sure that the escaped XML can be deserialized back into its original form
+            // Lets make sure that the escaped XML can be deserialized back into its original form.
+            //
+            // "\r" are deserialized into "\n" by the .NET XML serializer, thus we need to
+            // compensate for that.
+            message = message.Replace("\r", "\n");
+
             Deserialize().Root.Element(Namespace + "message").Value.ShouldBe(message);
         }
 
@@ -362,6 +391,9 @@ namespace Serilog.Sinks.Udp.TextFormatters
         // The following characters should not be escaped in a XML element
         [InlineData("Some \" message", "Some \" message")]
         [InlineData("Some ' message", "Some ' message")]
+        [InlineData("Some \n message", "Some \n message")]
+        [InlineData("Some \r message", "Some \r message")]
+        [InlineData("Some \t message", "Some \t message")]
         public void WriteEscapedExceptionElement(string message, string expected)
         {
             // Arrange
@@ -373,7 +405,12 @@ namespace Serilog.Sinks.Udp.TextFormatters
             // Assert
             output.ToString().ShouldContain($"<log4net:throwable>System.DivideByZeroException: {expected}</log4net:throwable>");
 
-            // Lets make sure that the escaped XML can be deserialized back into its original form
+            // Lets make sure that the escaped XML can be deserialized back into its original form.
+            //
+            // "\r" are deserialized into "\n" by the .NET XML serializer, thus we need to
+            // compensate for that.
+            message = message.Replace("\r", "\n");
+
             Deserialize().Root.Element(Namespace + "throwable").Value.ShouldBe($"System.DivideByZeroException: {message}");
         }
 

--- a/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4netTextFormatterShould.cs
+++ b/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4netTextFormatterShould.cs
@@ -35,6 +35,29 @@ namespace Serilog.Sinks.Udp.TextFormatters
             Deserialize().Root.Attribute("logger").Value.ShouldBe("source context");
         }
 
+        [Theory]
+        [InlineData("Some < source context", "Some &lt; source context")]
+        [InlineData("Some > source context", "Some &gt; source context")]
+        [InlineData("Some & source context", "Some &amp; source context")]
+        // The following characters should be escaped in a XML attribute
+        [InlineData("Some \" source context", "Some &quot; source context")]
+        [InlineData("Some ' source context", "Some &apos; source context")]
+        public void WriteEscapedLoggerAttribute(string sourceContext, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent();
+            logEvent.AddOrUpdateProperty(new LogEventProperty("SourceContext", new ScalarValue(sourceContext)));
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($" logger=\"{expected}\"");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Attribute("logger").Value.ShouldBe(sourceContext);
+        }
+
         [Fact]
         public void WriteTimestampAttribute()
         {
@@ -76,6 +99,29 @@ namespace Serilog.Sinks.Udp.TextFormatters
             Deserialize().Root.Attribute("thread").Value.ShouldBe("1");
         }
 
+        [Theory]
+        [InlineData("Some < thread", "Some &lt; thread")]
+        [InlineData("Some > thread", "Some &gt; thread")]
+        [InlineData("Some & thread", "Some &amp; thread")]
+        // The following characters should be escaped in a XML attribute
+        [InlineData("Some \" thread", "Some &quot; thread")]
+        [InlineData("Some ' thread", "Some &apos; thread")]
+        public void WriteEscapedTheadAttribute(string thread, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent();
+            logEvent.AddOrUpdateProperty(new LogEventProperty("ThreadId", new ScalarValue(thread)));
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($" thread=\"{expected}\"");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Attribute("thread").Value.ShouldBe(thread);
+        }
+
         [Fact]
         public void WriteUsernameAttribute()
         {
@@ -90,18 +136,64 @@ namespace Serilog.Sinks.Udp.TextFormatters
             Deserialize().Root.Attribute("username").Value.ShouldBe("some user");
         }
 
-        [Fact]
-        public void WriteDomainAttribute()
+        [Theory]
+        [InlineData("Some < username", "Some &lt; username")]
+        [InlineData("Some > username", "Some &gt; username")]
+        [InlineData("Some & username", "Some &amp; username")]
+        // The following characters should be escaped in a XML attribute
+        [InlineData("Some \" username", "Some &quot; username")]
+        [InlineData("Some ' username", "Some &apos; username")]
+        public void WriteEscapedUsernameAttribute(string username, string expected)
         {
             // Arrange
             var logEvent = Some.LogEvent();
-            logEvent.AddOrUpdateProperty(new LogEventProperty("ProcessName", new ScalarValue("some domain")));
+            logEvent.AddOrUpdateProperty(new LogEventProperty("EnvironmentUserName", new ScalarValue(username)));
 
             // Act
             formatter.Format(logEvent, output);
 
             // Assert
-            Deserialize().Root.Attribute("domain").Value.ShouldBe("some domain");
+            output.ToString().ShouldContain($" username=\"{expected}\"");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Attribute("username").Value.ShouldBe(username);
+        }
+
+        [Fact]
+        public void WriteDomainAttribute()
+        {
+            // Arrange
+            var logEvent = Some.LogEvent();
+            logEvent.AddOrUpdateProperty(new LogEventProperty("ProcessName", new ScalarValue("process name")));
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            Deserialize().Root.Attribute("domain").Value.ShouldBe("process name");
+        }
+
+        [Theory]
+        [InlineData("Some < process name", "Some &lt; process name")]
+        [InlineData("Some > process name", "Some &gt; process name")]
+        [InlineData("Some & process name", "Some &amp; process name")]
+        // The following characters should be escaped in a XML attribute
+        [InlineData("Some \" process name", "Some &quot; process name")]
+        [InlineData("Some ' process name", "Some &apos; process name")]
+        public void WriteEscapedDomainAttribute(string processName, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent();
+            logEvent.AddOrUpdateProperty(new LogEventProperty("ProcessName", new ScalarValue(processName)));
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($" domain=\"{expected}\"");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Attribute("domain").Value.ShouldBe(processName);
         }
 
         [Fact]
@@ -118,6 +210,29 @@ namespace Serilog.Sinks.Udp.TextFormatters
             Deserialize().Root.Element(Namespace + "locationInfo").Attribute("class").Value.ShouldBe("source context");
         }
 
+        [Theory]
+        [InlineData("Some < source context", "Some &lt; source context")]
+        [InlineData("Some > source context", "Some &gt; source context")]
+        [InlineData("Some & source context", "Some &amp; source context")]
+        // The following characters should be escaped in a XML attribute
+        [InlineData("Some \" source context", "Some &quot; source context")]
+        [InlineData("Some ' source context", "Some &apos; source context")]
+        public void WriteEscapedClassAttribute(string sourceContext, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent();
+            logEvent.AddOrUpdateProperty(new LogEventProperty("SourceContext", new ScalarValue(sourceContext)));
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($" class=\"{expected}\"");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Element(Namespace + "locationInfo").Attribute("class").Value.ShouldBe(sourceContext);
+        }
+
         [Fact]
         public void WriteMethodAttribute()
         {
@@ -131,9 +246,32 @@ namespace Serilog.Sinks.Udp.TextFormatters
             // Assert
             Deserialize().Root.Element(Namespace + "locationInfo").Attribute("method").Value.ShouldBe("Void Method()");
         }
-        
+
+        [Theory]
+        [InlineData("Some < method", "Some &lt; method")]
+        [InlineData("Some > method", "Some &gt; method")]
+        [InlineData("Some & method", "Some &amp; method")]
+        // The following characters should be escaped in a XML attribute
+        [InlineData("Some \" method", "Some &quot; method")]
+        [InlineData("Some ' method", "Some &apos; method")]
+        public void WriteEscapedMethodAttribute(string method, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent();
+            logEvent.AddOrUpdateProperty(new LogEventProperty("Method", new ScalarValue(method)));
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($" method=\"{expected}\"");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Element(Namespace + "locationInfo").Attribute("method").Value.ShouldBe(method);
+        }
+
         [Fact]
-        public void WriteMachineNameAttribute()
+        public void WriteHostNameAttribute()
         {
             // Arrange
             var logEvent = Some.LogEvent();
@@ -144,6 +282,29 @@ namespace Serilog.Sinks.Udp.TextFormatters
 
             // Assert
             Deserialize().Root.Element(Namespace + "properties").Element(Namespace + "data").Attribute("value").Value.ShouldBe("MachineName");
+        }
+
+        [Theory]
+        [InlineData("Some < hostname", "Some &lt; hostname")]
+        [InlineData("Some > hostname", "Some &gt; hostname")]
+        [InlineData("Some & hostname", "Some &amp; hostname")]
+        // The following characters should be escaped in a XML attribute
+        [InlineData("Some \" hostname", "Some &quot; hostname")]
+        [InlineData("Some ' hostname", "Some &apos; hostname")]
+        public void WriteEscapedHostNameAttribute(string hostname, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent();
+            logEvent.AddOrUpdateProperty(new LogEventProperty("MachineName", new ScalarValue(hostname)));
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($" <log4net:data name=\"log4net:HostName\" value=\"{expected}\"></log4net:data>");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Element(Namespace + "properties").Element(Namespace + "data").Attribute("value").Value.ShouldBe(hostname);
         }
 
         [Fact]
@@ -159,6 +320,28 @@ namespace Serilog.Sinks.Udp.TextFormatters
             Deserialize().Root.Element(Namespace + "message").Value.ShouldBe("Some message");
         }
 
+        [Theory]
+        [InlineData("Some < message", "Some &lt; message")]
+        [InlineData("Some > message", "Some &gt; message")]
+        [InlineData("Some & message", "Some &amp; message")]
+        // The following characters should not be escaped in a XML element
+        [InlineData("Some \" message", "Some \" message")]
+        [InlineData("Some ' message", "Some ' message")]
+        public void WriteEscapedMessageElement(string message, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent(message: message);
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($"<log4net:message>{expected}</log4net:message>");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Element(Namespace + "message").Value.ShouldBe(message);
+        }
+
         [Fact]
         public void WriteExceptionElement()
         {
@@ -170,6 +353,28 @@ namespace Serilog.Sinks.Udp.TextFormatters
 
             // Assert
             Deserialize().Root.Element(Namespace + "throwable").Value.ShouldNotBeNull();
+        }
+
+        [Theory]
+        [InlineData("Some < message", "Some &lt; message")]
+        [InlineData("Some > message", "Some &gt; message")]
+        [InlineData("Some & message", "Some &amp; message")]
+        // The following characters should not be escaped in a XML element
+        [InlineData("Some \" message", "Some \" message")]
+        [InlineData("Some ' message", "Some ' message")]
+        public void WriteEscapedExceptionElement(string message, string expected)
+        {
+            // Arrange
+            var logEvent = Some.LogEvent(exception: new DivideByZeroException(message));
+
+            // Act
+            formatter.Format(logEvent, output);
+
+            // Assert
+            output.ToString().ShouldContain($"<log4net:throwable>System.DivideByZeroException: {expected}</log4net:throwable>");
+
+            // Lets make sure that the escaped XML can be deserialized back into its original form
+            Deserialize().Root.Element(Namespace + "throwable").Value.ShouldBe($"System.DivideByZeroException: {message}");
         }
 
         private XDocument Deserialize()


### PR DESCRIPTION
Correctly XML escape all properties serialized by `Log4jTextFormatter` and `Log4netTextFormatter`.

Closes #51