### PR TITLE
Configure SourceLink to use deterministic builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 ### :syringe: Fixed
 
 - Configure [SourceLink](https://github.com/dotnet/sourcelink) to embed untracked sources
+- Configure [SourceLink](https://github.com/dotnet/sourcelink) to use deterministic builds when running on AppVeyor
 
 ## [7.0.0] - 2020-03-09
 

--- a/src/Serilog.Sinks.Udp/Serilog.Sinks.Udp.csproj
+++ b/src/Serilog.Sinks.Udp/Serilog.Sinks.Udp.csproj
@@ -20,16 +20,10 @@
     <!-- Embed symbols in NuGet package -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <!-- SourceLink -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <RepositoryUrl>https://github.com/FantasticFiasco/serilog-sinks-udp.git</RepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.*" />
-    <!-- SourceLink -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
@@ -43,6 +37,22 @@
 
   <ItemGroup>
     <None Include="assets\serilog-sink-nuget.png" Pack="true" PackagePath=""/>
+  </ItemGroup>
+
+  <!-- SourceLink -->
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RepositoryUrl>https://github.com/FantasticFiasco/serilog-sinks-udp.git</RepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CI)' == 'True'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Configure SourceLink to use deterministic builds when running on AppVeyor.