### PR TITLE
Add netstandard2.1 target & update test project to netcoreapp31

### DIFF
--- a/src/Serilog.Sinks.Udp/Serilog.Sinks.Udp.csproj
+++ b/src/Serilog.Sinks.Udp/Serilog.Sinks.Udp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Serilog.Sinks.Udp</AssemblyName>
     <Description>A Serilog sink sending UDP packages over the network.</Description>
-    <TargetFrameworks>net45;net461;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net461;netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Serilog</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Strong naming -->

--- a/test/Serilog.Sinks.Udp.Tests/Serilog.Sinks.Udp.Tests.csproj
+++ b/test/Serilog.Sinks.Udp.Tests/Serilog.Sinks.Udp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Serilog</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
- Add `netstandard2.1` target to `Serilog.Sinks.Udp` project
- Update `Serilog.Sinks.Udp.Tests` to target `netcoreapp3.1`

---

Closes #101