### PR TITLE
Refactor deprecated transient functionality

### DIFF
--- a/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
@@ -150,7 +150,7 @@ namespace Serilog
             try
             {
                 var client = UdpClientFactory.Create(localPort, family);
-                var sink = new UdpSink(client, remoteAddress, remotePort, formatter);
+                var sink = new BatchingSink(new UdpSink(client, remoteAddress, remotePort, formatter));
 
                 return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
             }

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/Private/BatchingSink.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/Private/BatchingSink.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2015-2022 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Serilog.Sinks.PeriodicBatching;
+
+namespace Serilog.Sinks.Udp.Private
+{
+    internal class BatchingSink : PeriodicBatchingSink
+    {
+        public BatchingSink(IBatchedLogEventSink sink)
+            : base(
+                sink,
+                new PeriodicBatchingSinkOptions
+                {
+                    BatchSizeLimit = 1000, Period = TimeSpan.FromSeconds(0.5)
+                })
+        {
+        }
+    }
+}


### PR DESCRIPTION
# Description

Let's refactor since some of the underlying functionality from `Serilog.Sinks.PeriodicBatching` now have been deprecated.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
