### PR TITLE
Allows specifying the encoding of strings sent over the network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :zap: Added
+
+- [BREAKING CHANGE] Support for specifying UDP datagram encoding (contributed by [@pedoc](https://github.com/pedoc))
+
 ## [8.0.1] - 2022-11-20
 
 ### :dizzy: Changed

--- a/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Net.Sockets;
+using System.Text;
 using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Formatting;
@@ -68,6 +69,7 @@ namespace Serilog
         /// <param name="formatProvider">
         /// Supplies culture-specific formatting information, or null.
         /// </param>
+        /// <param name="encoding">The string encoding sent over the network, if not specified, defaults to UTF-8.</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
@@ -80,7 +82,8 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             LoggingLevelSwitch levelSwitch = null,
             string outputTemplate = DefaultOutputTemplate,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            Encoding encoding=null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
@@ -95,7 +98,8 @@ namespace Serilog
                 formatter,
                 localPort,
                 restrictedToMinimumLevel,
-                levelSwitch);
+                levelSwitch,
+                encoding);
         }
 
         /// <summary>
@@ -132,6 +136,7 @@ namespace Serilog
         /// <param name="levelSwitch">
         /// A switch allowing the pass-through minimum level to be changed at runtime.
         /// </param>
+        /// <param name="encoding">The string encoding sent over the network, if not specified, defaults to UTF-8.</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
@@ -143,14 +148,15 @@ namespace Serilog
             ITextFormatter formatter,
             int localPort = 0,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            LoggingLevelSwitch levelSwitch = null)
+            LoggingLevelSwitch levelSwitch = null,
+            Encoding encoding=null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
 
             try
             {
                 var client = UdpClientFactory.Create(localPort, family);
-                var sink = new BatchingSink(new UdpSink(client, remoteAddress, remotePort, formatter));
+                var sink = new BatchingSink(new UdpSink(client, remoteAddress, remotePort, formatter,encoding));
 
                 return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
             }

--- a/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
@@ -69,7 +69,9 @@ namespace Serilog
         /// <param name="formatProvider">
         /// Supplies culture-specific formatting information, or null.
         /// </param>
-        /// <param name="encoding">The string encoding sent over the network, if not specified, defaults to UTF-8.</param>
+        /// <param name="encoding">
+        /// The string encoding sent over the network. The default is <see cref="Encoding.UTF8"/>.
+        /// </param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
@@ -83,7 +85,7 @@ namespace Serilog
             LoggingLevelSwitch levelSwitch = null,
             string outputTemplate = DefaultOutputTemplate,
             IFormatProvider formatProvider = null,
-            Encoding encoding=null)
+            Encoding encoding = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
@@ -136,7 +138,9 @@ namespace Serilog
         /// <param name="levelSwitch">
         /// A switch allowing the pass-through minimum level to be changed at runtime.
         /// </param>
-        /// <param name="encoding">The string encoding sent over the network, if not specified, defaults to UTF-8.</param>
+        /// <param name="encoding">
+        /// The string encoding sent over the network. The default is <see cref="Encoding.UTF8"/>.
+        /// </param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
@@ -149,14 +153,16 @@ namespace Serilog
             int localPort = 0,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             LoggingLevelSwitch levelSwitch = null,
-            Encoding encoding=null)
+            Encoding encoding = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
+
+            encoding = encoding ?? Encoding.UTF8;
 
             try
             {
                 var client = UdpClientFactory.Create(localPort, family);
-                var sink = new BatchingSink(new UdpSink(client, remoteAddress, remotePort, formatter,encoding));
+                var sink = new BatchingSink(new UdpSink(client, remoteAddress, remotePort, formatter, encoding));
 
                 return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
             }

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/Private/UdpSink.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/Private/UdpSink.cs
@@ -32,16 +32,19 @@ namespace Serilog.Sinks.Udp.Private
         private readonly IUdpClient client;
         private readonly RemoteEndPoint remoteEndPoint;
         private readonly ITextFormatter formatter;
+        private readonly Encoding encoding;
 
         public UdpSink(
             IUdpClient client,
             string remoteAddress,
             int remotePort,
-            ITextFormatter formatter)
+            ITextFormatter formatter,
+            Encoding encoding)
         {
             this.client = client ?? throw new ArgumentNullException(nameof(client));
             remoteEndPoint = new RemoteEndPoint(remoteAddress, remotePort);
             this.formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
+            this.encoding = encoding ?? Encoding.UTF8;
         }
 
         #region IBatchedLogEventSink Members
@@ -56,7 +59,7 @@ namespace Serilog.Sinks.Udp.Private
                     {
                         formatter.Format(logEvent, stringWriter);
 
-                        byte[] buffer = Encoding.UTF8.GetBytes(
+                        byte[] buffer = encoding.GetBytes(
                             stringWriter
                                 .ToString()
                                 .ToCharArray());

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/Private/UdpSink.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/Private/UdpSink.cs
@@ -44,7 +44,7 @@ namespace Serilog.Sinks.Udp.Private
             this.client = client ?? throw new ArgumentNullException(nameof(client));
             remoteEndPoint = new RemoteEndPoint(remoteAddress, remotePort);
             this.formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
-            this.encoding = encoding ?? Encoding.UTF8;
+            this.encoding = encoding;
         }
 
         #region IBatchedLogEventSink Members


### PR DESCRIPTION
# Description

Some log viewing tools (such as the popular https://github.com/CobaltFusion/DebugViewPP) cannot recognize UTF8 encoded characters, which will cause abnormal display.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
