### PR TITLE
Deprecate Log4jTextFormatter and Log4netTextFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ __Package__ - [Serilog.Sinks.Udp](https://www.nuget.org/packages/serilog.sinks.u
 - [Super simple to use](#super-simple-to-use)
 - [Typical use case](#typical-use-case)
 - [Event formatters](#event-formatters)
-  - [`Log4jTextFormatter`](#log4jtextformatter)
-  - [`Log4netTextFormatter`](#log4nettextformatter)
 - [Sample applications](#sample-applications)
 - [Install via NuGet](#install-via-nuget)
 - [Donations](#donations)
@@ -86,33 +84,7 @@ Taking it to the next level is when you as a team agree on sending the log event
 
 The event formatter is an output template on steroids. It has the responsibility of turning a single log event into a textual representation. It can serialize the log event into JSON, XML or anything else that matches the expectations of the receiver.
 
-The sink comes pre-loaded with two XML based event formatters. One is matching the log4j schema expected by Log2Console and the other is matching the log4net schema expected by [Log4View](http://www.log4view.com).
-
-### `Log4jTextFormatter`
-
-The log event is formatted according to the log4j XML schema expected by Log2Console.
-
-```xml
-<log4j:event logger="Some.Serilog.Context" timestamp="1184286222308" level="ERROR" thread="1">
-  <log4j:message>Something failed</log4j:message>
-  <log4j:throwable>An exception describing the failure<log4j:throwable>
-</log4j:event>
-```
-
-### `Log4netTextFormatter`
-
-The log event is formatted according to the log4net XML schema expected by Log4View.
-
-```xml
-<log4net:event logger="Some.Serilog.Context" timestamp="2017-09-01T22:00:00.000+02:00" level="DEBUG" thread="1" username="MACHINE\username" domain="dotnet">
-  <log4net:locationInfo class="Some.Serilog.Context" method="System.String Get(Int32)"/>
-  <log4net:properties>
-    <log4net:data name="log4net:HostName" value="MACHINE"/>
-  </log4net:properties>
-  <log4net:message>Something went wrong.</log4net:message>
-  <log4net:throwable>System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.</log4net:throwable>
-</log4net:event>
-```
+It is recommended to use the [Serilog.Formatting.Log4Net](https://github.com/serilog-contrib/serilog-formatting-log4net) NuGet package to format logs as log4net or log4j format. You can then use [Log4View](http://www.log4view.com) or [Log2Console](https://github.com/Statyk7/log2console) for example to look at the logs while they are transmitted over UDP.
 
 ## Sample applications
 

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/TextFormatters/Log4jTextFormatter.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/TextFormatters/Log4jTextFormatter.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Serilog.Events;
 using Serilog.Formatting;
 using System.IO;
@@ -23,6 +24,7 @@ namespace Serilog.Sinks.Udp.TextFormatters;
 /// <summary>
 /// Text formatter serializing log events into log4j compliant XML.
 /// </summary>
+[Obsolete("Consider using the Log4NetTextFormatter class from the Serilog.Formatting.Log4Net package instead, see https://github.com/serilog-contrib/serilog-formatting-log4net")]
 public class Log4jTextFormatter : ITextFormatter
 {
     private static readonly string SourceContextPropertyName = "SourceContext";

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/TextFormatters/Log4netTextFormatter.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/TextFormatters/Log4netTextFormatter.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Serilog.Events;
 using Serilog.Formatting;
 using System.IO;
@@ -22,6 +23,7 @@ namespace Serilog.Sinks.Udp.TextFormatters;
 /// <summary>
 /// Text formatter serializing log events into log4net compliant XML.
 /// </summary>
+[Obsolete("Consider using the Log4NetTextFormatter class from the Serilog.Formatting.Log4Net package instead, see https://github.com/serilog-contrib/serilog-formatting-log4net")]
 public class Log4netTextFormatter : ITextFormatter
 {
     private static readonly string SourceContextPropertyName = "SourceContext";

--- a/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4jTextFormatterShould.cs
+++ b/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4jTextFormatterShould.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 
 namespace Serilog.Sinks.Udp.TextFormatters;
 
+[Obsolete("Can be deleted once the Log4jTextFormatter class is removed")]
 public class Log4jTextFormatterShould
 {
     private static readonly XNamespace Namespace = "http://jakarta.apache.org/log4j/";

--- a/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4netTextFormatterShould.cs
+++ b/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/TextFormatters/Log4netTextFormatterShould.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 
 namespace Serilog.Sinks.Udp.TextFormatters;
 
+[Obsolete("Can be deleted once the Log4jTextFormatter class is removed")]
 public class Log4netTextFormatterShould
 {
     private static readonly XNamespace Namespace = "http://logging.apache.org/log4net/schemas/log4net-events-1.2/";


### PR DESCRIPTION
# Description

Recommend using [Serilog.Formatting.Log4Net](https://github.com/serilog-contrib/serilog-formatting-log4net) instead.

`Serilog.Formatting.Log4Net` is better that the provided `Log4jTextFormatter` and `Log4netTextFormatter` classes as it is configurable and well documented.

Disclaimer: I am the author of `Serilog.Formatting.Log4Net`. 😉

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
