### PR TITLE
feat: create configuration option for broadcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+- [BREAKING CHANGE] Support for broadcast packages (contributed by [@dnatov](https://github.com/dnatov))
+
 ### :zap: Added
 
 - [BREAKING CHANGE] Support for specifying UDP datagram encoding (contributed by [@pedoc](https://github.com/pedoc))

--- a/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
@@ -72,6 +72,9 @@ public static class LoggerSinkConfigurationExtensions
     /// <param name="encoding">
     /// The string encoding sent over the network. The default is <see cref="Encoding.UTF8"/>.
     /// </param>
+    /// <param name="enableBroadcast">
+    /// Enables broadcasting on the UDP Client.
+    /// </param>
     /// <returns>
     /// Logger configuration, allowing configuration to continue.
     /// </returns>
@@ -85,7 +88,8 @@ public static class LoggerSinkConfigurationExtensions
         LoggingLevelSwitch? levelSwitch = null,
         string outputTemplate = DefaultOutputTemplate,
         IFormatProvider? formatProvider = null,
-        Encoding? encoding = null)
+        Encoding? encoding = null,
+        bool enableBroadcast = false)
     {
         if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
         if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
@@ -101,7 +105,8 @@ public static class LoggerSinkConfigurationExtensions
             localPort,
             restrictedToMinimumLevel,
             levelSwitch,
-            encoding);
+            encoding,
+            enableBroadcast);
     }
 
     /// <summary>
@@ -141,6 +146,9 @@ public static class LoggerSinkConfigurationExtensions
     /// <param name="encoding">
     /// The string encoding sent over the network. The default is <see cref="Encoding.UTF8"/>.
     /// </param>
+    /// <param name="enableBroadcast">
+    /// Enables broadcasting on the UDP Client.
+    /// </param>
     /// <returns>
     /// Logger configuration, allowing configuration to continue.
     /// </returns>
@@ -153,7 +161,8 @@ public static class LoggerSinkConfigurationExtensions
         int localPort = 0,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         LoggingLevelSwitch? levelSwitch = null,
-        Encoding? encoding = null)
+        Encoding? encoding = null,
+        bool enableBroadcast = false)
     {
         if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
 
@@ -161,7 +170,7 @@ public static class LoggerSinkConfigurationExtensions
 
         try
         {
-            var client = UdpClientFactory.Create(localPort, family);
+            var client = UdpClientFactory.Create(localPort, family, enableBroadcast);
             var sink = new BatchingSink(new UdpSink(client, remoteAddress, remotePort, formatter, encoding));
 
             return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);

--- a/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Udp/LoggerSinkConfigurationExtensions.cs
@@ -55,6 +55,9 @@ public static class LoggerSinkConfigurationExtensions
     /// The TCP port from which the UDP client will communicate. The default is 0 and will
     /// cause the UDP client not to bind to a local port.
     /// </param>
+    /// <param name="enableBroadcast">
+    /// Whether the <see cref="UdpClient"/> may send broadcast packets.
+    /// </param>
     /// <param name="restrictedToMinimumLevel">
     /// The minimum level for events passed through the sink. The default is
     /// <see cref="LevelAlias.Minimum"/>.
@@ -72,9 +75,6 @@ public static class LoggerSinkConfigurationExtensions
     /// <param name="encoding">
     /// The string encoding sent over the network. The default is <see cref="Encoding.UTF8"/>.
     /// </param>
-    /// <param name="enableBroadcast">
-    /// Enables broadcasting on the UDP Client.
-    /// </param>
     /// <returns>
     /// Logger configuration, allowing configuration to continue.
     /// </returns>
@@ -84,12 +84,12 @@ public static class LoggerSinkConfigurationExtensions
         int remotePort,
         AddressFamily family,
         int localPort = 0,
+        bool enableBroadcast = false,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         LoggingLevelSwitch? levelSwitch = null,
         string outputTemplate = DefaultOutputTemplate,
         IFormatProvider? formatProvider = null,
-        Encoding? encoding = null,
-        bool enableBroadcast = false)
+        Encoding? encoding = null)
     {
         if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
         if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
@@ -103,10 +103,10 @@ public static class LoggerSinkConfigurationExtensions
             family,
             formatter,
             localPort,
+            enableBroadcast,
             restrictedToMinimumLevel,
             levelSwitch,
-            encoding,
-            enableBroadcast);
+            encoding);
     }
 
     /// <summary>
@@ -136,6 +136,9 @@ public static class LoggerSinkConfigurationExtensions
     /// The TCP port from which the UDP client will communicate. The default is 0 and will
     /// cause the UDP client not to bind to a local port.
     /// </param>
+    /// <param name="enableBroadcast">
+    /// Whether the <see cref="UdpClient"/> may send broadcast packets.
+    /// </param>
     /// <param name="restrictedToMinimumLevel">
     /// The minimum level for events passed through the sink. The default is
     /// <see cref="LevelAlias.Minimum"/>.
@@ -145,9 +148,6 @@ public static class LoggerSinkConfigurationExtensions
     /// </param>
     /// <param name="encoding">
     /// The string encoding sent over the network. The default is <see cref="Encoding.UTF8"/>.
-    /// </param>
-    /// <param name="enableBroadcast">
-    /// Enables broadcasting on the UDP Client.
     /// </param>
     /// <returns>
     /// Logger configuration, allowing configuration to continue.
@@ -159,10 +159,10 @@ public static class LoggerSinkConfigurationExtensions
         AddressFamily family,
         ITextFormatter formatter,
         int localPort = 0,
+        bool enableBroadcast = false,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         LoggingLevelSwitch? levelSwitch = null,
-        Encoding? encoding = null,
-        bool enableBroadcast = false)
+        Encoding? encoding = null)
     {
         if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
 

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/Private/UdpClientFactory.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/Private/UdpClientFactory.cs
@@ -25,6 +25,6 @@ public static class UdpClientFactory
     /// <summary>
     /// Gets or sets the factory creating instances of <see cref="IUdpClient"/>.
     /// </summary>
-    public static Func<int, AddressFamily, IUdpClient> Create { get; set; }
-        = (localPort, family) => new UdpClientWrapper(localPort, family);
+    public static Func<int, AddressFamily, bool, IUdpClient> Create { get; set; }
+        = (localPort, family, enableBroadcast) => new UdpClientWrapper(localPort, family, enableBroadcast);
 }

--- a/src/Serilog.Sinks.Udp/Sinks/Udp/Private/UdpClientWrapper.cs
+++ b/src/Serilog.Sinks.Udp/Sinks/Udp/Private/UdpClientWrapper.cs
@@ -23,7 +23,7 @@ internal class UdpClientWrapper : IUdpClient
 {
     private readonly UdpClient client;
 
-    public UdpClientWrapper(int localPort, AddressFamily family)
+    public UdpClientWrapper(int localPort, AddressFamily family, bool enableBroadcast)
     {
         if (localPort < IPEndPoint.MinPort || localPort > IPEndPoint.MaxPort) throw new ArgumentOutOfRangeException(nameof(localPort));
 
@@ -36,6 +36,9 @@ internal class UdpClientWrapper : IUdpClient
         {
             client.Client.DualMode = true;
         }
+
+        // Enable broadcasting
+        client.EnableBroadcast = enableBroadcast;
     }
 
     public Socket Client => client.Client;

--- a/test/Serilog.Sinks.Udp.Tests/SinkFixture.cs
+++ b/test/Serilog.Sinks.Udp.Tests/SinkFixture.cs
@@ -11,7 +11,7 @@ namespace Serilog;
 
 public abstract class SinkFixture : IDisposable
 {
-    private readonly Func<int, AddressFamily, IUdpClient> originalFactory;
+    private readonly Func<int, AddressFamily, bool, IUdpClient> originalFactory;
     private readonly UdpClientMock client;
 
     protected SinkFixture()
@@ -19,7 +19,7 @@ public abstract class SinkFixture : IDisposable
         originalFactory = UdpClientFactory.Create;
 
         client = new UdpClientMock();
-        UdpClientFactory.Create = (_, __) => client.Object;
+        UdpClientFactory.Create = (_, __, ___) => client.Object;
     }
 
     protected abstract string RemoteAddress { get; }

--- a/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/Private/UdpClientFactoryShould.cs
+++ b/test/Serilog.Sinks.Udp.Tests/Sinks/Udp/Private/UdpClientFactoryShould.cs
@@ -19,7 +19,7 @@ public class UdpClientFactoryShould : IDisposable
     public void UseDualModeOnInterNetworkV6()
     {
         // Act
-        client = UdpClientFactory.Create(0, AddressFamily.InterNetworkV6);
+        client = UdpClientFactory.Create(0, AddressFamily.InterNetworkV6, false);
 
         // Assert
         client.Client.DualMode.ShouldBeTrue();
@@ -31,7 +31,7 @@ public class UdpClientFactoryShould : IDisposable
     public async void SendPayload(string address, AddressFamily family)
     {
         // Arrange
-        client = UdpClientFactory.Create(0, family);
+        client = UdpClientFactory.Create(0, family, false);
 
         var ipAddress = IPAddress.Parse(address);
 


### PR DESCRIPTION
# Description

I encountered some issues with multiple network interfaces in which broadcast UDP messages would not work. I found that changing the `UDPClient.EnableBroadcast` property to true had fixed all of my issues. In our project I made the change but wanted to also provide this feature for other people to use.

The changes were simply adding an optional boolean option `enableBroadcast` on the static `LoggerConfiguration` class.
This option is passed into the `UDPClientWrapper` where it is set on the client.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
