### PR TITLE
Migrate .NET Framework to 4.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :zap: Added
+
+- Support for .NET Framework 4.6.2
+
 ### :skull: Removed
 
 - [BREAKING CHANGE] Remove support for .NET Standard 1.3, aligning with the [cross-platform targeting library guidance](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting)
+- [BREAKING CHANGE] Remove support for .NET Framework 4.6.1, aligning with the [.NET Framework support policy](https://learn.microsoft.com/lifecycle/products/microsoft-net-framework)
 
 ## [9.0.0] - 2023-10-19
 

--- a/src/Serilog.Sinks.Udp/Serilog.Sinks.Udp.csproj
+++ b/src/Serilog.Sinks.Udp/Serilog.Sinks.Udp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Serilog.Sinks.Udp</AssemblyName>
     <Description>A Serilog sink sending UDP packages over the network.</Description>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Serilog</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Strong naming -->
@@ -29,12 +29,12 @@
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
     <DefineConstants>$(DefineConstants);NET4</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
# Description

Migrate .NET Framework from 4.6.1 to 4.6.2, aligning with the [.NET Framework support policy](https://learn.microsoft.com/lifecycle/products/microsoft-net-framework).

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
